### PR TITLE
Rename SNS section to 関連ページ and add note link

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,8 +84,9 @@
             </ul>
         </section>
         <section class="sns">
-            <h2>SNS</h2>
+            <h2>関連ページ</h2>
             <ul>
+                <li><a href="https://note.com/012" target="_blank" rel="noopener">執筆したnote記事</a></li>
                 <li><a href="https://www.linkedin.com/in/akinen" target="_blank" rel="noopener">LinkedIn</a></li>
             </ul>
         </section>


### PR DESCRIPTION
### Motivation
- Make the site section label more general by renaming `SNS` to `関連ページ` to better reflect links to external resources. 
- Surface authored content by adding a direct link to the author's `note` article above the `LinkedIn` link. 
- Keep the site navigation clear and prioritize the most relevant external pages for visitors. 

### Description
- Renamed the section heading from `SNS` to `関連ページ` in `index.html`.
- Inserted a new list item linking to `https://note.com/012` with the label `執筆したnote記事` placed above the existing `LinkedIn` link.
- Only `index.html` was modified; no other files were changed.

### Testing
- Served the site locally using `python -m http.server` on port 8000 and confirmed the page loads successfully. 
- Captured a full-page screenshot using Playwright saved to `artifacts/related-pages.png` to verify the new link and heading render as expected. 
- No automated unit tests were run because this is a static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958b3ca8208832393efcafb8c129a16)