### PR TITLE
Improve global typography settings

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -21,16 +21,16 @@
 
 body {
     font-family: "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Noto Sans JP", "Yu Gothic", "Meiryo", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-    font-size: clamp(0.95rem, 0.9rem + 0.3vw, 1.05rem);
-    line-height: 1.75;
+    font-size: clamp(1rem, 0.96rem + 0.25vw, 1.08rem);
+    line-height: 1.8;
     color: #333;
     background-color: #f9f9f9;
 }
 
 .container {
     max-width: 800px;
-    margin: 2rem auto;
-    padding: 1rem;
+    margin: 2.5rem auto;
+    padding: 2rem;
     background: #fff;
     border-radius: 4px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -38,7 +38,7 @@ body {
 
 header,
 section {
-    margin-bottom: 2rem;
+    margin-bottom: 2.5rem;
 }
 
 header h1,
@@ -47,8 +47,8 @@ h3 {
     font-kerning: normal;
     font-feature-settings: "palt";
     word-break: auto-phrase;
-    line-height: 1.35;
-    letter-spacing: 0.02em;
+    line-height: 1.3;
+    letter-spacing: 0.005em;
 }
 
 header h1 {
@@ -65,17 +65,17 @@ h2 {
 
 h3 {
     font-size: clamp(1.15rem, 1rem + 0.6vw, 1.4rem);
-    margin: 1rem 0 0.5rem;
+    margin: 1.25rem 0 0.75rem;
 }
 
 p {
-    margin-bottom: 1rem;
+    margin-bottom: 1.25rem;
 }
 
 ul {
     list-style: disc;
-    margin-left: 1.5rem;
-    line-height: 1.7;
+    margin-left: 1.75rem;
+    line-height: 1.75;
 }
 
 a {

--- a/styles.css
+++ b/styles.css
@@ -4,9 +4,25 @@
     box-sizing: border-box;
 }
 
+:root {
+    line-break: strict;
+    overflow-wrap: anywhere;
+    text-autospace: normal;
+    text-spacing-trim: trim-start;
+}
+
+:root:lang(ja) {
+    font-kerning: none;
+}
+
+:root:lang(en) {
+    font-kerning: normal;
+}
+
 body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-    line-height: 1.6;
+    font-family: "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Noto Sans JP", "Yu Gothic", "Meiryo", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+    font-size: clamp(0.95rem, 0.9rem + 0.3vw, 1.05rem);
+    line-height: 1.75;
     color: #333;
     background-color: #f9f9f9;
 }
@@ -25,20 +41,30 @@ section {
     margin-bottom: 2rem;
 }
 
+header h1,
+h2,
+h3 {
+    font-kerning: normal;
+    font-feature-settings: "palt";
+    word-break: auto-phrase;
+    line-height: 1.35;
+    letter-spacing: 0.02em;
+}
+
 header h1 {
-    font-size: 2rem;
+    font-size: clamp(1.9rem, 1.6rem + 1.2vw, 2.4rem);
     margin-bottom: 0.5rem;
 }
 
 h2 {
-    font-size: 1.5rem;
+    font-size: clamp(1.4rem, 1.2rem + 0.8vw, 1.8rem);
     margin-bottom: 1rem;
     border-bottom: 2px solid #ddd;
     padding-bottom: 0.5rem;
 }
 
 h3 {
-    font-size: 1.2rem;
+    font-size: clamp(1.15rem, 1rem + 0.6vw, 1.4rem);
     margin: 1rem 0 0.5rem;
 }
 
@@ -49,6 +75,7 @@ p {
 ul {
     list-style: disc;
     margin-left: 1.5rem;
+    line-height: 1.7;
 }
 
 a {
@@ -58,4 +85,16 @@ a {
 
 a:hover {
     text-decoration: underline;
+}
+
+pre,
+time,
+input:not([type="button" i], [type="submit" i], [type="reset" i]),
+textarea,
+[contenteditable] {
+    text-autospace: no-autospace;
+}
+
+pre {
+    text-spacing-trim: space-all;
 }

--- a/styles.css
+++ b/styles.css
@@ -52,6 +52,7 @@ h3 {
 }
 
 header h1 {
+    font-family: "Avenir Next", "Helvetica Neue", "Segoe UI", Arial, sans-serif;
     font-size: clamp(1.9rem, 1.6rem + 1.2vw, 2.4rem);
     margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
### Motivation
- The site needed overall typographic improvements for Japanese/English content including line-breaking, kerning, autospace, and spacing-trim behavior to increase readability and reduce spacing artifacts.
- Provide a safer default font stack and fluid sizing so text scales better across viewports and devices.

### Description
- Added global typographic defaults in `:root` including `line-break: strict`, `overflow-wrap: anywhere`, `text-autospace: normal`, and `text-spacing-trim: trim-start`, and language-specific `font-kerning` rules for `:lang(ja)` and `:lang(en)` in `styles.css`.
- Refined the base font stack to prefer Japanese UI fonts and applied a fluid base `font-size` with `clamp()` and increased `line-height` for improved legibility in the `body` selector.
- Tuned heading styles (`h1`, `h2`, `h3`) to enable `font-kerning: normal`, `font-feature-settings: "palt"`, `word-break: auto-phrase`, tighter `line-height`, and fluid sizes via `clamp()`; also increased list `line-height`.
- Added safe autospace/spacing overrides for `pre`, `time`, `input`, `textarea`, and `[contenteditable]` (e.g. `text-autospace: no-autospace` and `text-spacing-trim: space-all`) to avoid unwanted gaps in code-like and user-input elements.

### Testing
- Started a local server with `python -m http.server` and captured a visual snapshot with a Playwright script, and the script completed successfully (screenshot saved as an artifact).
- No automated unit tests were applicable for these static CSS changes and none were run.
- Changes were committed to `styles.css` and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b499061088323ae53c3309a5c225c)