### PR TITLE
Increase h3 top margin to 40px

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -66,7 +66,7 @@ h2 {
 
 h3 {
     font-size: clamp(1.15rem, 1rem + 0.6vw, 1.4rem);
-    margin: 1.25rem 0 0.75rem;
+    margin: 40px 0 0.75rem;
 }
 
 p {


### PR DESCRIPTION
### Motivation
- Provide more vertical spacing above level-3 headings by increasing the top margin to 40px.

### Description
- Updated the `h3` rule in `styles.css` to `margin: 40px 0 0.75rem;`, replacing the previous `margin: 1.25rem 0 0.75rem;`.

### Testing
- Started a local server and generated a visual snapshot via Playwright which produced `artifacts/h3-margin.png`, confirming the spacing change; no unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b8ef6b4208323a21282bb8337029d)