### PR TITLE
Add note article links under related pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,13 @@
         <section class="sns">
             <h2>関連ページ</h2>
             <ul>
-                <li><a href="https://note.com/012" target="_blank" rel="noopener">執筆したnote記事</a></li>
+                <li>
+                    <a href="https://note.com/012" target="_blank" rel="noopener">執筆したnote記事</a>
+                    <ul>
+                        <li><a href="https://note.com/012/n/n8f046e2b8cf2" target="_blank" rel="noopener">インターフェイスと料理</a></li>
+                        <li><a href="https://note.com/012/n/nf24890e6ed3a" target="_blank" rel="noopener">デザイナーも知っておきたい、マーケティングの考え方</a></li>
+                    </ul>
+                </li>
                 <li><a href="https://www.linkedin.com/in/akinen" target="_blank" rel="noopener">LinkedIn</a></li>
             </ul>
         </section>


### PR DESCRIPTION
### Motivation
- Provide direct access to two individual Note articles from the "執筆したnote記事" related pages entry so visitors can reach those posts easily.

### Description
- Updated `index.html` to nest two new links under the existing `執筆したnote記事` list: `インターフェイスと料理` (`https://note.com/012/n/n8f046e2b8cf2`) and `デザイナーも知っておきたい、マーケティングの考え方` (`https://note.com/012/n/nf24890e6ed3a`).

### Testing
- Launched a static server with `python -m http.server 8000`, ran a Playwright script which produced `artifacts/note-links.png` to verify the change, and committed the update with `git commit` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c5593bcfc8323a38ddf96ba16ba74)