### PR TITLE
Adjust paragraph and list font size to 1rem

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -70,10 +70,13 @@ h3 {
 }
 
 p {
+    font-size: 1rem;
     margin-bottom: 1.25rem;
 }
 
+ol,
 ul {
+    font-size: 1rem;
     list-style: disc;
     margin-left: 1.2rem;
     line-height: 1.75;


### PR DESCRIPTION
### Motivation
- Make non-heading text (paragraphs and lists) use `1rem` instead of the larger clamp-based size so body copy and lists render at a consistent, slightly smaller typographic scale.

### Description
- Added `font-size: 1rem` to the `p`, `ol`, and `ul` selectors in `styles.css` to enforce the new size for paragraphs and lists.

### Testing
- Captured a visual verification screenshot with Playwright (`artifacts/font-size.png`), and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d064d2fb48323936c39e1c0258884)