### PR TITLE
Add .nojekyll marker for GitHub Pages builds

### DIFF
--- a/public/.nojekyll
+++ b/public/.nojekyll
@@ -1,0 +1,1 @@
+disable jekyll


### PR DESCRIPTION
### Motivation

- Prevent GitHub Pages from running Jekyll so the Astro-generated static site is served as-is by adding a marker.

### Description

- Add `public/.nojekyll` containing `disable jekyll` to disable Jekyll processing for Pages.

### Testing

- No automated tests were run for this static file change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69730ad062b08323af57dec3d8b04c5e)