### PR TITLE
Place .nojekyll marker at repository root

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+disable jekyll


### PR DESCRIPTION
### Motivation
- Ensure GitHub Pages does not run Jekyll by placing the `.nojekyll` marker at the repository root where Pages looks for it.

### Description
- Move `public/.nojekyll` to the repo root as `.nojekyll` with content `disable jekyll` and amend the commit message to `Place nojekyll marker at repo root`.

### Testing
- No automated tests were run for this static file change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69730ad062b08323af57dec3d8b04c5e)