### PR TITLE
Inline critical styles to reduce render-blocking chain

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,7 +23,118 @@ const pageDescription =
     <meta property="og:url" content="https://akinen.com/" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{pageTitle}</title>
-    <link rel="stylesheet" href="/styles.css" />
+    <style>
+      {`* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+:root {
+    line-break: strict;
+    overflow-wrap: anywhere;
+    text-autospace: normal;
+    text-spacing-trim: trim-start;
+}
+
+:root:lang(ja) {
+    font-kerning: none;
+}
+
+:root:lang(en) {
+    font-kerning: normal;
+}
+
+body {
+    font-family: "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Noto Sans JP", "Yu Gothic", "Meiryo", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+    font-size: clamp(1rem, 0.96rem + 0.25vw, 1.08rem);
+    line-height: 1.8;
+    color: #333;
+    background-color: #f9f9f9;
+}
+
+.container {
+    max-width: 800px;
+    margin: 2.5rem auto;
+    padding: 2rem;
+    background: #fff;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+header,
+section {
+    margin-bottom: 2.5rem;
+}
+
+header h1,
+h2,
+h3 {
+    font-kerning: normal;
+    font-feature-settings: "palt";
+    word-break: auto-phrase;
+    line-height: 1.3;
+    letter-spacing: 0.005em;
+}
+
+header h1 {
+    font-family: "Avenir Next", "Helvetica Neue", "Segoe UI", Arial, sans-serif;
+    font-size: clamp(1.9rem, 1.6rem + 1.2vw, 2.4rem);
+    margin-bottom: 0.5rem;
+}
+
+h2 {
+    font-size: clamp(1.4rem, 1.2rem + 0.8vw, 1.8rem);
+    margin-bottom: 1rem;
+    border-bottom: 1.5px solid #ccc;
+    padding-bottom: 0.5rem;
+}
+
+h3 {
+    font-size: clamp(1.15rem, 1rem + 0.6vw, 1.4rem);
+    margin: 40px 0 0.75rem;
+}
+
+p {
+    font-size: 1rem;
+    margin-bottom: 1.25rem;
+}
+
+ol,
+ul {
+    font-size: 1rem;
+    list-style: disc;
+    margin-left: 1.2rem;
+    line-height: 1.75;
+}
+
+@media (min-width: 768px) {
+    .container {
+        padding: 3rem;
+    }
+}
+
+a {
+    color: #0066cc;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+pre,
+time,
+input:not([type="button" i], [type="submit" i], [type="reset" i]),
+textarea,
+[contenteditable] {
+    text-autospace: no-autospace;
+}
+
+pre {
+    text-spacing-trim: space-all;
+}`}
+    </style>
   </head>
   <body>
     <main class="container">


### PR DESCRIPTION
### Motivation
- Reduce Lighthouse "Network dependency tree" warnings by removing an external render-blocking stylesheet request. 
- Shorten the critical request chain and improve first paint by delivering essential CSS directly in the document head. 

### Description
- Replaced the external stylesheet link `/<styles.css>` with an inline `<style>` block containing the contents of `public/styles.css` in `src/pages/index.astro`. 
- The change embeds critical layout and typography rules directly into the page head so the browser can render without fetching `/styles.css`. 
- Only `src/pages/index.astro` was modified and the page markup/content otherwise remains unchanged. 

### Testing
- No automated tests were executed because this is a static, client-side style change. 
- A commit was created with the message `Inline critical styles to reduce request chain` and the modified file was staged and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69730d02584883238043ae983153217b)