### PR TITLE
Hide private-mode dialog by default and remove dialog outline

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -127,6 +127,7 @@ body.is-private .private-only {
 
 .private-mode-modal {
     border: none;
+    outline: none;
     position: fixed;
     top: 50%;
     left: 50%;
@@ -137,8 +138,12 @@ body.is-private .private-only {
     width: min(420px, 90vw);
     z-index: 11;
     box-shadow: 0 10px 24px rgba(0, 0, 0, 0.2);
-    display: grid;
+    display: none;
     gap: 1rem;
+}
+
+.private-mode-modal[open] {
+    display: grid;
 }
 
 .private-mode-modal::backdrop {


### PR DESCRIPTION
### Motivation
- Prevent the "あいことばを入力" modal from appearing on initial page load so it only shows when `Privateモード` is activated.
- Remove the visible black outline around the dialog to match the intended visual design.

### Description
- Update `public/styles.css` to add `outline: none` and change `.private-mode-modal` to `display: none` so the dialog is hidden by default.
- Add a rule `.private-mode-modal[open] { display: grid; }` so the dialog becomes visible only when it has the `open` attribute (i.e. after `showModal()` / user action).

### Testing
- Launched the dev server with `npm run dev` and confirmed the site served successfully.
- Executed a Playwright script to load the page and capture a screenshot; the saved artifact `artifacts/private-modal-hidden.png` shows the modal hidden as expected (succeeded).
- No unit tests were added or modified for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697315de85f0832393cec11c28d2fd96)