### PR TITLE
Adjust private modal layout on mobile

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -156,6 +156,12 @@ body.is-private .private-only {
     padding-bottom: 0;
 }
 
+.private-mode-description {
+    margin: 0;
+    color: #666;
+    font-size: 14px;
+}
+
 .private-mode-input {
     padding: 0.6rem 0.8rem;
     border: 1px solid #ccc;
@@ -182,6 +188,13 @@ body.is-private .private-only {
     background: #fff;
     color: #111;
     border-color: #111;
+}
+
+@media (max-width: 640px) {
+    .private-mode-modal {
+        top: 96px;
+        transform: translate(-50%, 0);
+    }
 }
 
 pre,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -144,6 +144,9 @@ const pageDescription =
     </main>
     <dialog class="private-mode-modal" aria-labelledby="private-mode-title" data-private-modal>
       <h2 id="private-mode-title">あいことばを入力</h2>
+      <p class="private-mode-description">
+        より詳細な経歴を閲覧できるようになります。ご入用の方は、小澤までご連絡ください
+      </p>
       <input class="private-mode-input" type="password" autocomplete="off" data-private-input />
       <div class="private-mode-actions">
         <button class="private-mode-cancel" type="button" data-private-cancel>キャンセル</button>


### PR DESCRIPTION
### Motivation
- モバイル表示時にプライベートモード用の「あいことば」入力モーダルを画面中央ではなく上から96pxに表示する要件に対応するための変更です。
- モーダル内に補助説明文を追加して、詳細な経歴の閲覧方法を案内するための変更です。

### Description
- `src/pages/index.astro` にモーダル見出しの下段として説明文を追加し、`<p class="private-mode-description">` を挿入しました.
- `public/styles.css` に `.private-mode-description` のスタイルを追加し、文字色を `#666`、`font-size: 14px` に設定しました.
- 小画面向けに `@media (max-width: 640px)` を追加して `.private-mode-modal` の `top` を `96px` に変更し、`transform: translate(-50%, 0)` に切り替えてモーダルを指定位置に表示するようにしました.
- 変更対象ファイルは `src/pages/index.astro` と `public/styles.css` です.

### Testing
- ローカル開発サーバーを `npm run dev -- --host 0.0.0.0 --port 4321` で起動してページを確認し、サーバーは起動しました and served at `http://localhost:4321/`.
- Playwright を用いてモバイルビューポート (`width: 375`, `height: 812`) でトップページを開き、`Privateモード` ボタンをクリックしてモーダル表示のスクリーンショットを取得し、スクリーンショット生成は成功しました (`artifacts/private-modal-mobile.png`)。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973352239608323b12697d3b876f326)