### PR TITLE
Update Stockr achievement text and minor site copy/metadata fixes

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 const pageTitle = "Akinori OZAWA | デジタルプロダクトデザイナー";
 const pageDescription =
-  "Akinori OZAWAの履歴書。7年以上のUX/UIデザインおよびフロントエンド開発経験を持つプロダクトデザイナーの経歴、実績、登壇履歴をご紹介します。";
+  "Akinori OZAWAの履歴書。8年以上のUX/UIデザインおよびフロントエンド開発経験を持つプロダクトデザイナーの経歴、実績、登壇履歴をご紹介します。";
 ---
 <!DOCTYPE html>
 <html lang="ja">
@@ -17,7 +17,7 @@ const pageDescription =
     <meta property="og:title" content={pageTitle} />
     <meta
       property="og:description"
-      content="Akinori OZAWAは、7年以上のUX/UIデザインおよびフロントエンド開発経験を持つプロダクトデザイナー。"
+      content="Akinori OZAWAは、8年以上のUX/UIデザインおよびフロントエンド開発経験を持つプロダクトデザイナー。"
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://akinen.com/" />
@@ -97,7 +97,7 @@ const pageDescription =
           <h3>株式会社ビルディット</h3>
           <p>プロダクトデザイナー（2019年11月〜2021年10月）</p>
           <ul>
-            <li>新規自社事業「Stockr」アプリのコンセプト立案／体験設計／UIデザイン全般をリード。</li>
+            <li>自社新規事業「Stockr」の0→1フェーズにおいて、コアコンセプトの立案からUI/UXデザインの実装までを一気通貫で牽引し、プロダクトの具現化に貢献。</li>
           </ul>
         </article>
         <article>
@@ -125,14 +125,14 @@ const pageDescription =
           </li>
           <li>2023.02 社内勉強会「XRの近況とUX/UIについて」</li>
           <li><a href="https://www.facebook.com/ackiena/posts/pfbid0pM9b89XQcdWzgGNqkLrn8L2yoV4djjRLKfSL7knTofNxjEPwhEAY6HkekkNQqq1sl" target="_blank" rel="noopener">2022.07 Figma Japan Community Event - Show &amp; Tell 登壇</a></li>
-          <li>2020 - 2022 八王子IT勉強会「ゆるはち.it」運営・登壇</li>
+          <li>2020 - 2022 八王子IT勉強会「Yuruhachi.it」運営・登壇</li>
         </ul>
       </section>
       <section class="sns">
         <h2>関連ページ</h2>
         <ul>
           <li>
-            <a href="https://note.com/012" target="_blank" rel="noopener">執筆したnote記事</a>
+            <a href="https://note.com/012" target="_blank" rel="noopener">note</a>
             <ul>
               <li>
                 <a href="https://note.com/012/n/n8f046e2b8cf2" target="_blank" rel="noopener">インターフェイスと料理</a>


### PR DESCRIPTION
### Motivation
- Ensure public-facing copy accurately reflects current experience and requested phrasing changes. 
- Replace the Buildit/Stockr achievement line with the more descriptive 0→1 wording provided. 
- Improve a couple of visible labels for clarity and consistency.

### Description
- Replaced the Stockr bullet under `株式会社ビルディット` in `src/pages/index.astro` with the requested wording for the 0→1 phase and end-to-end contribution. 
- Updated `pageDescription` and Open Graph `og:description` in `src/pages/index.astro` from "7年以上" to "8年以上". 
- Renamed the meetup label from "ゆるはち.it" to "Yuruhachi.it" and simplified the link label "執筆したnote記事" to "note" in `src/pages/index.astro`.

### Testing
- Ran `npm run build`, which completed successfully. 
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4321` and confirmed the page served successfully. 
- Captured an updated page screenshot via a Playwright script to verify the visible text changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c9894cc34832398413efe42fe60b8)