### PR TITLE
Open private details via "もっと詳しく" link and remove header Privateモード

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -104,19 +104,6 @@ a:hover {
     text-decoration: underline;
 }
 
-.private-mode-button {
-    border: none;
-    background: none;
-    padding: 0;
-    color: #0066cc;
-    font: inherit;
-    cursor: pointer;
-}
-
-.private-mode-button:hover {
-    text-decoration: underline;
-}
-
 .private-only {
     display: none;
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,7 +29,6 @@ const pageDescription =
     <main class="container">
       <header class="page-header">
         <h1>Akinori OZAWA</h1>
-        <button class="private-mode-button" type="button" data-private-open>Privateモード</button>
       </header>
       <section class="overview">
         <h2>概要</h2>
@@ -50,7 +49,7 @@ const pageDescription =
             </li>
             <li>Steamゲームの仕様検討・UIデザイン</li>
             <li>
-              もっと詳しく（あいことばが必要です）
+              <a href="#" data-private-open>もっと詳しく</a>
               <ul class="private-only">
                 <li>
                   <strong>アバター集中支援アプリ「gogh」のプロダクトオーナーシップ</strong>
@@ -190,7 +189,10 @@ const pageDescription =
           }
         };
 
-        privateButton?.addEventListener("click", openPrivateModal);
+        privateButton?.addEventListener("click", (event) => {
+          event.preventDefault();
+          openPrivateModal();
+        });
         privateCancel?.addEventListener("click", closePrivateModal);
         privateModal.addEventListener("click", (event) => {
           if (event.target === privateModal) {


### PR DESCRIPTION
### Motivation
- Make the private details reachable from the inline "もっと詳しく" item instead of the top-right header control so users can open the password modal from the experience list. 
- Prevent the anchor from navigating away when clicked and reuse the existing modal logic. 
- Remove now-unused header trigger styles to keep the stylesheet tidy.

### Description
- Removed the header `Privateモード` button from `src/pages/index.astro` so the header shows only the name. 
- Replaced the static text `もっと詳しく（あいことばが必要です）` with an anchor `<a href="#" data-private-open>もっと詳しく</a>` in `src/pages/index.astro`. 
- Updated the event listener to call `event.preventDefault()` and open the existing password modal when the new link is clicked in `src/pages/index.astro`. 
- Deleted the unused `.private-mode-button` CSS rules from `public/styles.css`.

### Testing
- Ran `npm run build` which completed successfully. 
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4321` and it started without errors. 
- Executed an automated Playwright script that navigated to the page and clicked `a[data-private-open]`, and the password modal was displayed (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e54731a48323b8f2d6662738713f)