### PR TITLE
Add major IP Roblox game design entry to ambr experience

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -65,6 +65,12 @@ const pageDescription =
                   </ul>
                 </li>
                 <li>
+                  <strong>大手IPゲームのデザイン</strong>
+                  <ul>
+                    <li>『<a href="https://prtimes.jp/main/html/rd/p/000000069.000043299.html" target="_blank" rel="noopener">果てしなきスカーレット</a>』 『<a href="https://prtimes.jp/main/html/rd/p/000000049.000043299.html" target="_blank" rel="noopener">野生の島のロズ</a>』 『<a href="https://prtimes.jp/main/html/rd/p/000000042.000043299.html" target="_blank" rel="noopener">進撃の巨人</a>』 といった作品のRobloxゲームのUIデザイン・ロゴデザイン等を担当。</li>
+                  </ul>
+                </li>
+                <li>
                   <strong>公式HPの立ち上げ・運用</strong>
                   <ul>
                     <li>年間 xxx Viewを有する公式サイトの立ち上げおよび大規模リニューアルを担当。UX視点に基づいた情報設計からビジュアルデザイン、実装までを行い、ユーザビリティ向上とブランド価値の最大化に貢献。</li>


### PR DESCRIPTION
### Motivation
- Add a new private experience item to the ambr section to document UI/logo design work on major IP Roblox titles and place it before `公式HPの立ち上げ・運用`.

### Description
- Updated `src/pages/index.astro` to insert a new `<li>` block titled "大手IPゲームのデザイン" that links to and references `果てしなきスカーレット`, `野生の島のロズ`, and `進撃の巨人`, describing Roblox UI and logo design responsibilities.

### Testing
- Built the site with `npm run build`, started the dev server with `npm run dev -- --host 0.0.0.0 --port 4321`, and captured a full-page screenshot via a Playwright script, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e7776410832380b332ce83c0826e)