### PR TITLE
Update overview and meta descriptions to reflect latest gogh metrics

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 const pageTitle = "Akinori OZAWA | デジタルプロダクトデザイナー";
 const pageDescription =
-  "Akinori OZAWAの履歴書。8年以上のUX/UIデザインおよびフロントエンド開発経験を持つプロダクトデザイナーの経歴、実績、登壇履歴をご紹介します。";
+  "UX/UIデザインおよびフロントエンド開発における8年超の専門性を基盤に、事業成長を牽引するプロダクトデザイナー。自社事業「gogh」はグローバル200万DL／売上20万本を突破。";
 ---
 <!DOCTYPE html>
 <html lang="ja">
@@ -17,7 +17,7 @@ const pageDescription =
     <meta property="og:title" content={pageTitle} />
     <meta
       property="og:description"
-      content="Akinori OZAWAは、8年以上のUX/UIデザインおよびフロントエンド開発経験を持つプロダクトデザイナー。"
+      content="UX/UIデザインおよびフロントエンド開発における8年超の専門性を基盤に、事業成長を牽引するプロダクトデザイナー。"
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://akinen.com/" />
@@ -33,9 +33,9 @@ const pageDescription =
       <section class="overview">
         <h2>概要</h2>
         <p>
-          8年以上のUX/UIデザインおよびフロントエンド開発経験のあるプロダクトデザイナー。<br />
-          立ち上げ期から携わっている自社事業「gogh」は、リリース後1年以内にオーガニックで世界150万DLを達成。<br />
-          toC/toBの経験を活かし、デザインや施策立案を通じて、プロダクトのPMFおよびグロースに貢献します。
+          UX/UIデザインおよびフロントエンド開発における8年超の専門性を基盤に、事業成長を牽引するプロダクトデザイナー。<br />
+          立ち上げ期から携わっている自社事業「gogh」は、リリース後1年以内にグローバルで150万DLを達成し、現在は200万DL／売上20万本を突破。<br />
+          toC/toB双方の知見と実装力を武器に、グロースと事業価値の向上にコミットします。
         </p>
       </section>
       <section class="experience">


### PR DESCRIPTION
### Motivation
- Align the site's public profile and SEO/OG metadata with the latest product achievements and messaging. 
- Make the displayed overview copy consistent with updated business metrics for `gogh` and emphasize broader capability (toC/toB and implementation skills).

### Description
- Updated the `pageDescription` constant in `src/pages/index.astro` to the new overview copy emphasizing "8年超の専門性" and `gogh` metrics (現在200万DL／売上20万本). 
- Replaced the `og:description` content with the new concise overview phrasing for OGP consistency. 
- Replaced the visible "概要" paragraph in `src/pages/index.astro` with the three-sentence text supplied (including the updated `gogh` milestones and toC/toB phrasing).

### Testing
- Ran `npm run build` and the build completed successfully. 
- Launched the dev server using `npm run dev -- --host 0.0.0.0 --port 4321` and the site served locally without errors. 
- Captured a Playwright screenshot of `http://127.0.0.1:4321/` to verify the updated overview text rendered as expected, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eb43cf61483239bb972d83f343c74)