### PR TITLE
関連ページに gogh の Note 記事を追加

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -147,6 +147,9 @@ const pageDescription =
             <a href="https://note.com/012" target="_blank" rel="noopener">note</a>
             <ul>
               <li>
+                <a href="https://note.com/ambr/n/nbccabde15b46" target="_blank" rel="noopener">200万DLを突破した作業集中プロダクト「gogh」のデザイン思想</a>
+              </li>
+              <li>
                 <a href="https://note.com/012/n/n8f046e2b8cf2" target="_blank" rel="noopener">インターフェイスと料理</a>
               </li>
               <li>


### PR DESCRIPTION
### Motivation
- `関連ページ` セクションの `note` リスト先頭に、指定された gogh の記事リンクを追加するため。

### Description
- `src/pages/index.astro` の `関連ページ` 内 `note` の子リスト先頭に `https://note.com/ambr/n/nbccabde15b46` へのリンクを追加した。

### Testing
- 実行した自動テストは `npm run build` で、ビルドは正常に完了した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c168fbeff48323b9153ec2162b3529)