### PR TITLE
Add goghにおける取り組み link and remove インターフェイスと料理 note

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -49,6 +49,9 @@ const pageDescription =
             </li>
             <li>Steamゲームの仕様検討・UIデザイン</li>
             <li>
+              <a href="https://note.com/ambr/n/nbccabde15b46" target="_blank" rel="noopener">goghにおける取り組み</a>
+            </li>
+            <li>
               <a href="#" data-private-open>もっと詳しく</a>
               <ul class="private-only">
                 <li>
@@ -148,9 +151,6 @@ const pageDescription =
             <ul>
               <li>
                 <a href="https://note.com/ambr/n/nbccabde15b46" target="_blank" rel="noopener">200万DLを突破した作業集中プロダクト「gogh」のデザイン思想</a>
-              </li>
-              <li>
-                <a href="https://note.com/012/n/n8f046e2b8cf2" target="_blank" rel="noopener">インターフェイスと料理</a>
               </li>
               <li>
                 <a href="https://note.com/012/n/nf24890e6ed3a" target="_blank" rel="noopener">デザイナーも知っておきたい、マーケティングの考え方</a>


### PR DESCRIPTION
### Motivation
- Add the requested `goghにおける取り組み` text link to the 株式会社ambr experience before the `もっと詳しく` entry and remove the obsolete `インターフェイスと料理` note link from related pages to match content requirements.

### Description
- Updated `src/pages/index.astro` to insert a new list item linking to `https://note.com/ambr/n/nbccabde15b46` immediately before the `もっと詳しく` entry. 
- Removed the `インターフェイスと料理` entry from the `関連ページ > note` list.

### Testing
- Ran `npm run build` and the static site built successfully with no build errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6b3f78ef083239251fb82de9cdea2)