### PR TITLE
Add Zenn link to related pages section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -157,6 +157,7 @@ const pageDescription =
               </li>
             </ul>
           </li>
+          <li><a href="https://zenn.dev/012" target="_blank" rel="noopener">Zenn</a></li>
           <li><a href="https://www.linkedin.com/in/akinen" target="_blank" rel="noopener">LinkedIn</a></li>
         </ul>
       </section>


### PR DESCRIPTION
### Motivation
- Add a Zenn link to the "関連ページ" (Related Pages) list so visitors can access the author's Zenn profile as requested.

### Description
- Inserted a new list item linking to Zenn (`https://zenn.dev/012`) directly above the existing LinkedIn entry in `src/pages/index.astro`.

### Testing
- Ran `npm run build` and the site built successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf405ebf488323999e1e7eca8ad4ee)