### PR TITLE
役職表記を更新

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -42,7 +42,7 @@ const pageDescription =
         <h2>経歴</h2>
         <article>
           <h3>株式会社ambr</h3>
-          <p>プロダクトデザイナー（2023年9月～現在）</p>
+          <p>プロダクトデザイン／UIディレクション（2023年9月～現在）</p>
           <ul>
             <li>
               アバター集中支援アプリ「<a href="https://gogh.gg/" target="_blank" rel="noopener">gogh（ゴッホ）</a>」の仕様検討、体験設計、UIデザイン


### PR DESCRIPTION
### Motivation
- 表示文言の更新依頼に伴い、経歴ページの役職表記を反映するため。  

### Description
- `src/pages/index.astro` の経歴セクションで `プロダクトデザイナー（2023年9月～現在）` を `プロダクトデザイン／UIディレクション（2023年9月～現在）` に置換しました。  

### Testing
- `rg -n "プロダクトデザイン／UIディレクション" src/pages/index.astro` を実行して新しい文言の反映を確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ddafaa308323848011fdb1259cc5)