### PR TITLE
経歴セクションの2社項目をドロップダウン表示に変更

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -195,3 +195,31 @@ textarea,
 pre {
     text-spacing-trim: space-all;
 }
+
+.experience-dropdown {
+    margin-top: 40px;
+}
+
+.experience-dropdown summary {
+    list-style: none;
+    cursor: pointer;
+}
+
+.experience-dropdown summary::-webkit-details-marker {
+    display: none;
+}
+
+.experience-dropdown-title {
+    display: inline-block;
+    font-size: clamp(1.15rem, 1rem + 0.6vw, 1.4rem);
+    font-kerning: normal;
+    font-feature-settings: "palt";
+    word-break: auto-phrase;
+    line-height: 1.3;
+    letter-spacing: 0.005em;
+    margin-bottom: 0.75rem;
+}
+
+.experience-dropdown[open] summary {
+    margin-bottom: 0.75rem;
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -108,22 +108,26 @@ const pageDescription =
             </li>
           </ul>
         </article>
-        <article>
-          <h3>株式会社ビルディット</h3>
+        <details class="experience-dropdown">
+          <summary>
+            <span class="experience-dropdown-title">株式会社ビルディット</span>
+          </summary>
           <p>プロダクトデザイナー（2019年11月〜2021年10月）</p>
           <ul>
             <li>自社新規事業「Stockr」の0→1フェーズにおいて、コアコンセプトの立案からUI/UXデザインの実装までを一気通貫で牽引し、プロダクトの具現化に貢献。</li>
           </ul>
-        </article>
-        <article>
-          <h3>面白法人カヤック</h3>
+        </details>
+        <details class="experience-dropdown">
+          <summary>
+            <span class="experience-dropdown-title">面白法人カヤック</span>
+          </summary>
           <p>フロントエンドエンジニア（2018年4月〜2019年8月）</p>
           <ul>
             <li>
               大規模ゲームSNS「Lobi」および 国内最大のトーナメントPF「Tonamel」のサービス基盤刷新（Angular→Nuxt）に参画し、利用者拡大・開発の生産性向上を見据えたアーキテクチャ移行を実現。
             </li>
           </ul>
-        </article>
+        </details>
       </section>
       <section class="speaking">
         <h2>登壇履歴</h2>


### PR DESCRIPTION
### Motivation
- 経歴一覧のうち「株式会社ビルディット」と「面白法人カヤック」を折りたたみ可能にしてページの視認性を高めるための変更です。 
- 見出しのフォント印象は維持したまま、ユーザーが必要に応じて詳細を展開できるUIにする意図です。

### Description
- `src/pages/index.astro` の該当 `article` 要素をそれぞれ `details.experience-dropdown` に置換し、社名を `summary > span.experience-dropdown-title` として表示するようにしました。 
- `public/styles.css` にドロップダウン用のスタイルを追加し、`summary` のマーカー非表示、カーソル変更、開閉時の余白調整を行いました。 
- タイトル用クラス `experience-dropdown-title` で既存の `h3` 相当のタイポグラフィ（フォントサイズ、カーニング、字間、行間）を合わせフォント印象を維持しました。 

### Testing
- `npm run build` を実行し、`astro build` による静的サイト生成が正常に完了することを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ab4ed5448323998357789190601b)