### PR TITLE
経歴セクションのドロップダウン見出しを太字化し開閉アイコンを追加

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -203,6 +203,18 @@ pre {
 .experience-dropdown summary {
     list-style: none;
     cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.experience-dropdown summary::after {
+    content: "▼";
+    display: inline-block;
+    flex-shrink: 0;
+    transform: rotate(-90deg);
+    transition: transform 0.2s ease;
 }
 
 .experience-dropdown summary::-webkit-details-marker {
@@ -212,6 +224,7 @@ pre {
 .experience-dropdown-title {
     display: inline-block;
     font-size: clamp(1.15rem, 1rem + 0.6vw, 1.4rem);
+    font-weight: 700;
     font-kerning: normal;
     font-feature-settings: "palt";
     word-break: auto-phrase;
@@ -222,4 +235,8 @@ pre {
 
 .experience-dropdown[open] summary {
     margin-bottom: 0.75rem;
+}
+
+.experience-dropdown[open] summary::after {
+    transform: rotate(0deg);
 }


### PR DESCRIPTION
### Motivation
- 経歴一覧の会社名見出しに視認性と操作性を持たせるため、見出しを太字にし右側に開閉アイコンを追加して開閉状態が分かるようにする。 

### Description
- `public/styles.css` にて `.experience-dropdown summary` を `flex` レイアウト化してタイトルとアイコンを左右に配置するようにした。 
- `summary::after` で `▼` アイコンを追加し、デフォルトで `transform: rotate(-90deg)`、`[open]` 時に `rotate(0deg)` として向きが変わるトグル挙動を実装した。 
- `.experience-dropdown-title` に `font-weight: 700` を追加して見出しを太字化した。 

### Testing
- `rg -n` による該当箇所の検索で `src/pages/index.astro` 内の該当 `details`/`summary` を確認できることを確認しました（コマンド実行は成功）。 
- `nl` によるファイル表示で `public/styles.css` の変更内容を確認しました（コマンド実行は成功）。 
- `git diff -- public/styles.css` で差分を確認し、`git commit -m "経歴ドロップダウン見出しの太字化と矢印トグルを追加"` が成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08acb49f708323af8f369a0f92fcfd)