### PR TITLE
東京海上日動システムズの経歴をドロップダウン化

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -90,8 +90,10 @@ const pageDescription =
             </li>
           </ul>
         </article>
-        <article>
-          <h3>東京海上日動システムズ - デジタルイノベーション開発部 兼 戦略企画部</h3>
+        <details class="experience-dropdown">
+          <summary>
+            <span class="experience-dropdown-title">東京海上日動システムズ - デジタルイノベーション開発部 兼 戦略企画部</span>
+          </summary>
           <p>シニアエンジニア / インハウスデザイナー（2021年11月〜2023年8月）</p>
           <ul>
             <li>
@@ -107,7 +109,7 @@ const pageDescription =
               <strong>デザインシステム運用</strong>: 社内標準となるUIカタログおよびデザインシステムの更新・運用をリードし、大規模組織における開発効率化を推進。
             </li>
           </ul>
-        </article>
+        </details>
         <details class="experience-dropdown">
           <summary>
             <span class="experience-dropdown-title">株式会社ビルディット</span>


### PR DESCRIPTION
### Motivation
- 表示の一貫性向上のため、東京海上日動システムズの経歴を他の経歴項目と同じ折りたたみ可能な表示に統一します。

### Description
- `src/pages/index.astro` 内の該当する `<article>` を既存の `.experience-dropdown` スタイルを使った `<details class="experience-dropdown">` / `<summary>` ラッパーに置き換え、本文の内容は変更していません。

### Testing
- `npm run build` によるビルドが成功し、生成された `dist/index.html` に対象項目が `<details class="experience-dropdown">` として出力され全体でドロップダウンが3件あることを Python スクリプトで検証し、`npx playwright` によるフルページスクリーンショット取得も成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d0e717d988323a37a945017172831)