### PR TITLE
Improve AI search metadata

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,22 @@
+# Akinori OZAWA
+
+> Akinori OZAWA（akinen）は、UX/UIデザインとフロントエンド開発の専門性を持つデジタルプロダクトデザイナーです。
+
+## Profile
+
+- Site: https://akinen.com/
+- Role: デジタルプロダクトデザイナー
+- Expertise: UX/UIデザイン、プロダクトデザイン、フロントエンド開発、XR UI、Roblox UI、Figma、AIとデザイン
+- Current company: 株式会社ambr
+- Key product: アバター集中支援アプリ「gogh」
+
+## Links
+
+- note: https://note.com/012
+- Zenn: https://zenn.dev/012
+- LinkedIn: https://www.linkedin.com/in/akinen
+- Speaker Deck: https://speakerdeck.com/akinen
+
+## Summary for AI assistants
+
+Akinori OZAWA is a Japanese digital product designer with more than eight years of experience in UX/UI design and frontend engineering. He contributes to product strategy, user experience design, UI design, and implementation for consumer and business products. His work includes gogh, XR UI prototyping, Roblox UI, design systems, and talks about AI and design.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://akinen.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://akinen.com/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../.astro/types.d.ts" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,29 +1,93 @@
 ---
 const pageTitle = "Akinori OZAWA | デジタルプロダクトデザイナー";
 const pageDescription =
-  "UX/UIデザインおよびフロントエンド開発における8年超の専門性を基盤に、事業成長を牽引するプロダクトデザイナー。自社事業「gogh」はグローバル200万DL／売上20万本を突破。";
+  "UX/UIデザインおよびフロントエンド開発における8年超の専門性を基盤に、事業成長を牽引するプロダクトデザイナー。自社事業「gogh」はグローバル250万DL／売上30万本を突破。";
+
+const canonicalUrl = "https://akinen.com/";
+const personJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "@id": `${canonicalUrl}#person`,
+  name: "Akinori OZAWA",
+  alternateName: ["Akinori Ozawa", "小澤 章徳", "akinen"],
+  url: canonicalUrl,
+  jobTitle: "デジタルプロダクトデザイナー",
+  description: pageDescription,
+  knowsAbout: [
+    "UX/UIデザイン",
+    "プロダクトデザイン",
+    "フロントエンド開発",
+    "XR UI",
+    "Roblox UI",
+    "Figma",
+    "AIとデザイン"
+  ],
+  worksFor: {
+    "@type": "Organization",
+    name: "株式会社ambr"
+  },
+  sameAs: [
+    "https://note.com/012",
+    "https://zenn.dev/012",
+    "https://www.linkedin.com/in/akinen",
+    "https://speakerdeck.com/akinen"
+  ]
+};
+const profilePageJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "ProfilePage",
+  "@id": `${canonicalUrl}#profile`,
+  url: canonicalUrl,
+  name: pageTitle,
+  description: pageDescription,
+  inLanguage: "ja",
+  mainEntity: {
+    "@id": `${canonicalUrl}#person`
+  }
+};
+const webSiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "@id": `${canonicalUrl}#website`,
+  url: canonicalUrl,
+  name: pageTitle,
+  description: pageDescription,
+  inLanguage: "ja",
+  publisher: {
+    "@id": `${canonicalUrl}#person`
+  }
+};
 ---
 <!DOCTYPE html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
     <meta name="description" content={pageDescription} />
+    <meta name="author" content="Akinori OZAWA" />
     <meta
       name="keywords"
       content="Akinori OZAWA, 履歴書, プロダクトデザイナー, UX, UI, フロントエンド, 経歴, 登壇履歴"
     />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://akinen.com/" />
+    <link rel="canonical" href={canonicalUrl} />
+    <meta property="og:site_name" content="Akinori OZAWA" />
     <meta property="og:title" content={pageTitle} />
     <meta
       property="og:description"
-      content="UX/UIデザインおよびフロントエンド開発における8年超の専門性を基盤に、事業成長を牽引するプロダクトデザイナー。"
+      content={pageDescription}
     />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://akinen.com/" />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:locale" content="ja_JP" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={pageTitle} />
+    <meta name="twitter:description" content={pageDescription} />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{pageTitle}</title>
     <link rel="stylesheet" href="/styles.css" />
+    <script type="application/ld+json" set:html={JSON.stringify(personJsonLd)} />
+    <script type="application/ld+json" set:html={JSON.stringify(profilePageJsonLd)} />
+    <script type="application/ld+json" set:html={JSON.stringify(webSiteJsonLd)} />
   </head>
   <body>
     <main class="container">


### PR DESCRIPTION
### Motivation

- Bring on-page metadata in line with current content and improve discoverability for crawlers and AI assistants without altering the visible design or layout. 
- Provide structured knowledge graph data so search engines and LLMs can better identify the person, profile page, and site entities. 
- Make the site easier for bots and AI agents to index and summarize by adding standard crawling and summary artifacts.

### Description

- Updated `src/pages/index.astro` to adjust `pageDescription`, add `canonicalUrl`, an `author` meta tag, enhanced Open Graph and Twitter metadata, and embedded JSON-LD for `Person`, `ProfilePage`, and `WebSite` entities. 
- Replaced hardcoded canonical/OG URL values with the `canonicalUrl` variable and injected JSON-LD using `<script type="application/ld+json" set:html={...} />`, keeping the page visuals unchanged. 
- Added `public/robots.txt`, `public/sitemap.xml`, and `public/llms.txt` to improve crawler behavior and supply an AI-readable profile summary. 
- Added `src/env.d.ts` to capture Astro type references for build-time type resolution.

### Testing

- Ran the site build with `npm run build`, which completed successfully and produced the static output (build completed and pages generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a329c80854483238db1d16d7cd9b42c)