### PR TITLE
Change page title to コンテキストデザイナー

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-const pageTitle = "Akinori OZAWA | デジタルプロダクトデザイナー";
+const pageTitle = "Akinori OZAWA | コンテキストデザイナー";
 const pageDescription =
   "UX/UIデザインおよびフロントエンド開発における8年超の専門性を基盤に、事業成長を牽引するプロダクトデザイナー。自社事業「gogh」はグローバル250万DL／売上30万本を突破。";
 


### PR DESCRIPTION
### Motivation
- The site page title used “デジタルプロダクトデザイナー” and needed to be updated to “コンテキストデザイナー” to reflect the desired job title.

### Description
- Replaced `const pageTitle = "Akinori OZAWA | デジタルプロダクトデザイナー";` with `const pageTitle = "Akinori OZAWA | コンテキストデザイナー";` in `src/pages/index.astro` and committed the change.

### Testing
- Ran `npm run build` which completed successfully, and `npm test -- --runInBand` could not be run because the package has no `test` script.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3660f5afd88323b0b2d4760bc4a4fe)