### PR TITLE
Remove two entries from Speaking history

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -211,14 +211,12 @@ const webSiteJsonLd = {
           <li>
             <a href="https://aidesign2ndstage.peatix.com/" target="_blank" rel="noopener"><span data-ja="2025.04 CrossRel「AIとデザインのセカンドステージ」登壇" data-en="2025.04 Spoke at CrossRel, &quot;AI and Design: The Second Stage&quot;">2025.04 CrossRel「AIとデザインのセカンドステージ」登壇</span></a>
           </li>
-          <li><span data-ja="2025.03 DESIGN CAMPUS「デザインとAIのこれから」登壇" data-en="2025.03 Spoke at DESIGN CAMPUS, &quot;The Future of Design and AI&quot;">2025.03 DESIGN CAMPUS「デザインとAIのこれから」登壇</span></li>
           <li>
             2023.12 <a href="https://spectrumfest2023.studio.site/en" target="_blank" rel="noopener"><span data-ja="Spectrum Tokyo Festival 2023「3D空間を扱うUI表現とユーザビリティ」" data-en="Spectrum Tokyo Festival 2023, &quot;UI Expression and Usability for 3D Spaces&quot;">Spectrum Tokyo Festival 2023「3D空間を扱うUI表現とユーザビリティ」</span></a>
           </li>
           <li>
             2023.06 <a href="https://speakerdeck.com/akinen/figmatobezeldehazimeruxruipurototaipingu" target="_blank" rel="noopener"><span data-ja="DIST.39 「 FigmaとBeziではじめるXRUIプロトタイピング」" data-en="DIST.39, &quot;XR UI Prototyping with Figma and Bezi&quot;">DIST.39 「 FigmaとBeziではじめるXRUIプロトタイピング」</span></a>
           </li>
-          <li><span data-ja="2023.02 社内勉強会「XRの近況とUX/UIについて」" data-en="2023.02 Internal study session: &quot;Recent XR Trends and UX/UI&quot;">2023.02 社内勉強会「XRの近況とUX/UIについて」</span></li>
           <li><a href="https://www.facebook.com/ackiena/posts/pfbid0pM9b89XQcdWzgGNqkLrn8L2yoV4djjRLKfSL7knTofNxjEPwhEAY6HkekkNQqq1sl" target="_blank" rel="noopener"><span data-ja="2022.07 Figma Japan Community Event - Show &amp; Tell 登壇" data-en="2022.07 Spoke at Figma Japan Community Event - Show &amp; Tell">2022.07 Figma Japan Community Event - Show &amp; Tell 登壇</span></a></li>
           <li><span data-ja="2020 - 2022 八王子IT勉強会「Yuruhachi.it」運営・登壇" data-en="2020 - 2022 Organized and spoke at Hachioji IT meetup &quot;Yuruhachi.it&quot;">2020 - 2022 八王子IT勉強会「Yuruhachi.it」運営・登壇</span></li>
         </ul>


### PR DESCRIPTION
### Motivation
- Remove two speaking entries from the Speaking history section to update the public-facing events list.

### Description
- Deleted two `<li>` entries from `src/pages/index.astro` corresponding to the 2025.03 DESIGN CAMPUS and 2023.02 internal study session items.

### Testing
- Ran `npm run build` and the build completed successfully.
- Ran `git diff --check` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbedc20808323b26b5db5c2f834c5)