### PR TITLE
Add profile subtitle under Akinori OZAWA

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -64,6 +64,12 @@ header h1 {
     margin-bottom: 0.5rem;
 }
 
+.profile-subtitle {
+    color: #777;
+    font-size: 16px;
+    margin-bottom: 0;
+}
+
 h2 {
     font-size: clamp(1.4rem, 1.2rem + 0.8vw, 1.8rem);
     margin-bottom: 1rem;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -92,7 +92,10 @@ const webSiteJsonLd = {
   <body>
     <main class="container">
       <header class="page-header">
-        <h1>Akinori OZAWA</h1>
+        <div class="profile-title">
+          <h1>Akinori OZAWA</h1>
+          <p class="profile-subtitle">長野県出身／一児の父／空手道初段</p>
+        </div>
         <nav class="language-toggle" aria-label="Language selector">
           <button type="button" class="language-toggle-button is-active" data-lang-switch="ja" aria-pressed="true">JP</button>
           <span aria-hidden="true">/</span>


### PR DESCRIPTION
### Motivation
- Add the requested Japanese subtitle beneath the “Akinori OZAWA” heading and style it to match the provided design (16px, #777). 

### Description
- Inserted a `div.profile-title` wrapper in `src/pages/index.astro` containing the existing `h1` and a new `p.profile-subtitle` with the text `長野県出身／一児の父／空手道初段`, and added `.profile-subtitle` CSS to `public/styles.css` with `color: #777`, `font-size: 16px`, and `margin-bottom: 0;`.

### Testing
- Ran `npm run build` which completed successfully, and captured a visual verification with `npx --yes playwright@1.53.1 screenshot http://127.0.0.1:4321/ /tmp/akinen-subtitle.png`, confirming the subtitle is rendered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f88bcf160832387b5b4066c58d554)