### PR TITLE
Remove marketing article related link

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -233,9 +233,6 @@ const webSiteJsonLd = {
               <li>
                 <a href="https://note.com/ambr/n/nbccabde15b46" target="_blank" rel="noopener"><span data-ja="200万DLを突破した作業集中プロダクト「gogh」のデザイン思想" data-en="Design philosophy behind gogh, a focus product with over 2 million downloads">200万DLを突破した作業集中プロダクト「gogh」のデザイン思想</span></a>
               </li>
-              <li>
-                <a href="https://note.com/012/n/nf24890e6ed3a" target="_blank" rel="noopener"><span data-ja="デザイナーも知っておきたい、マーケティングの考え方" data-en="Marketing concepts designers should know">デザイナーも知っておきたい、マーケティングの考え方</span></a>
-              </li>
             </ul>
           </li>
           <li><a href="https://zenn.dev/012" target="_blank" rel="noopener">Zenn</a></li>


### PR DESCRIPTION
### Motivation
- Remove the Note article link titled 「デザイナーも知っておきたい、マーケティングの考え方」 from the related pages to update the site's links.

### Description
- Deleted the Note link HTML block from `src/pages/index.astro` inside the "関連ページ" section while preserving the surrounding list structure.

### Testing
- Ran `npm install --no-audit --no-fund` and `npm run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a423c52ea1c8323be9b732393ed1085)